### PR TITLE
Make the superstructure work on unrelated databases

### DIFF
--- a/build_superstructure.ipynb
+++ b/build_superstructure.ipynb
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "# Select a superstructure project\n",
-    "proj_name = \"superstructure\"\n",
+    "proj_name = \"bernhard_work\"\n",
     "bw.projects.set_current(proj_name)"
    ]
   },
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_dbs = [\"ei36_cutoff_IMAGE_SSP2_SS\", \"ecoinvent_SSP2_2020\", \"ecoinvent_SSP2_2025\"]"
+    "test_dbs = [\"A\", \"B\"]"
    ]
   },
   {
@@ -63,9 +63,10 @@
    "outputs": [],
    "source": [
     "# Initialize the builder.\n",
-    "# - Compares the first database against the others.\n",
-    "# - Adds exchanges from others missing from first to first.\n",
-    "bld = Builder.superstructure_from_databases(test_dbs)"
+    "# - (Optional) Creates the superstructure database.\n",
+    "# - Compares the superstructure database against the others.\n",
+    "# - Adds both missing activities and exchanges to the superstructure.\n",
+    "bld = Builder.superstructure_from_databases(test_dbs, \"C\")"
    ]
   },
   {
@@ -75,8 +76,10 @@
    "outputs": [],
    "source": [
     "# Take the superstructure and delta databases\n",
-    "# - Construct a DataFrame from all exchanges.\n",
-    "bld.build_complete_superstructure()"
+    "# - Construct a DataFrame from all biosphere, technosphere and production exchanges.\n",
+    "# NOTE: This might only fill in the '*_database', '*_key' and scenario columns.\n",
+    "#  Using the `finalize_superstructure` method will fill in the missing information.\n",
+    "bld.build_superstructure()"
    ]
   },
   {
@@ -96,6 +99,7 @@
    "outputs": [],
    "source": [
     "# Filter the DataFrame of all exchanges where there is no difference.\n",
+    "# NOTE: This is not always required.\n",
     "bld.filter_superstructure()"
    ]
   },
@@ -125,9 +129,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Fill out the 'to_*' columns with the 'to_key' information.\n",
-    "df = bld.superstructure.copy()\n",
-    "df = Builder.finalize_superstructure(df)"
+    "# Fill out the 'from' and 'to' columns with the 'key' information.\n",
+    "bld.finalize_superstructure()"
    ]
   },
   {
@@ -136,7 +139,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df"
+    "# The final draft of the superstructure scenario flows.\n",
+    "# NOTE: The first scenario column is the superstructure database itself.\n",
+    "# NOTE2: If the superstructure was built from scratch, all values will be 0.\n",
+    "#  Take this into account when saving/using this flow scenario dataframe.\n",
+    "bld.superstructure"
    ]
   },
   {
@@ -153,7 +160,8 @@
    "outputs": [],
    "source": [
     "### Now, export both the superstructure database and the flow scenario file.\n",
-    "db = bw.Database(\"ei36_cutoff_IMAGE_SSP2_SS\")\n",
+    "db = bw.Database(\"C\")\n",
+    "db.process()\n",
     "local_dir = Path.cwd()"
    ]
   },
@@ -188,7 +196,7 @@
    "source": [
     "# Now, save the flow scenarios to an excel file.\n",
     "excel_file = local_dir / \"{}_flow_scenarios.xlsx\".format(bld.name)\n",
-    "df.to_excel(excel_file, index=False)"
+    "bld.superstructure.to_excel(excel_file, index=False)"
    ]
   }
  ],

--- a/build_superstructure.ipynb
+++ b/build_superstructure.ipynb
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "# Select a superstructure project\n",
-    "proj_name = \"bernhard_work\"\n",
+    "proj_name = \"superstructure\"\n",
     "bw.projects.set_current(proj_name)"
    ]
   },

--- a/src/brightway.py
+++ b/src/brightway.py
@@ -168,30 +168,3 @@ def structure_exchanges(data: List[dict], super_db: str, deltas: set) -> List[Ex
     altered_exchanges = map(alter_data, data)
     new_exchanges = [Exchange(**exc) for exc in altered_exchanges]
     return new_exchanges
-
-
-def nullify_exchanges(data: List[dict]) -> List[dict]:
-    """Take a list of exchange dictionaries, extract all the amounts
-    and set the 'amount' in the dictionaries to 0."""
-    def set_null(d):
-        d["amount"] = 0
-        return d
-    nulled = list(map(set_null, data))
-    return nulled
-
-
-def swap_exchange_activities(data: dict, super_db: str, delta_set: set) -> Exchange:
-    """Take the exchange data and replace one or two activities inside with
-    new ones containing the same information.
-
-    This works best with activities constructed like those of ecoinvent.
-    """
-    in_key = data.get("input", ("",))
-    out_key = data.get("output", ("",))
-    if in_key[0] in delta_set:
-        data["input"] = (super_db, in_key[1])
-    if out_key[0] in delta_set:
-        data["output"] = (super_db, out_key[1])
-    # Constructing the Exchange this way will cause a new row to be written
-    e = Exchange(**data)
-    return e

--- a/src/brightway.py
+++ b/src/brightway.py
@@ -152,7 +152,7 @@ def find_missing_exchanges(superstruct: set, delta: str) -> (set, list):
 def select_exchange_data(db_name: str):
     query = (ED.select(ED.data)
              .where((ED.output_database == db_name) &
-                    (ED.type.in_(["biosphere", "technosphere"])))
+                    (ED.type.in_(["biosphere", "technosphere", "production"])))
              .tuples())
     data = (x[0] for x in query.iterator())
     return data

--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -43,12 +43,16 @@ class Builder(object):
         return builder
 
     @classmethod
-    def superstructure_from_databases(cls, databases: List[str]) -> 'Builder':
+    def superstructure_from_databases(cls, databases: List[str], superstructure: str) -> 'Builder':
+        """Given a list of database names and the name of the superstructure,
+        upgrade or create the superstructure database.
         """
-        docstring
-        """
-        assert len(databases) > 1, "Multiple items required"
+        assert len(databases) >= 1, "At least one database should be included"
+        assert len(databases) == len(set(databases)), "Duplicates are not allowed in the databases"
         assert all(db in bw.databases for db in databases), "All databases must exist in the project"
+        if superstructure not in bw.databases:
+            db = bw.Database(superstructure)
+            db.register()
         initial, deltas = databases[0], databases[1:]
         print("Superstructure: {}, deltas: {}".format(initial, ", ".join(deltas)))
         builder = cls.initialize(initial, deltas)

--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -53,9 +53,6 @@ class Builder(object):
         if superstructure not in bw.databases:
             db = bw.Database(superstructure)
             db.register()
-        initial, deltas = databases[0], databases[1:]
-        print("Superstructure: {}, deltas: {}".format(initial, ", ".join(deltas)))
-        builder = cls.initialize(initial, deltas)
         print("Superstructure: {}, deltas: {}".format(superstructure, ", ".join(databases)))
         builder = cls.initialize(superstructure, databases)
         print("Amount of activities in superstructure: {}".format(len(builder.unique_codes)))

--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -108,7 +108,7 @@ class Builder(object):
                 if i % 1000 == 0:
                     txn.commit()
 
-    def build_complete_superstructure(self) -> None:
+    def build_superstructure(self) -> None:
         """After initializing the superstructure, construct difference data."""
         assert self.name is not None, "Superstructure name is not set."
         assert self.selected_deltas, "No deltas found for superstructure."
@@ -173,6 +173,15 @@ class Builder(object):
         else:
             print("No unknown keys found.")
 
+    def finalize_superstructure(self) -> None:
+        """Ensure the dataframe is complete by matching the output activity
+        keys.
+        """
+        substitute = convert_key_to_fields(self.superstructure.loc[:, FROM_ALL])
+        self.superstructure[substitute.columns] = substitute
+        substitute = convert_key_to_fields(self.superstructure.loc[:, TO_ALL])
+        self.superstructure[substitute.columns] = substitute
+
     @staticmethod
     def construct_ss_dictionary(data: Iterable) -> dict:
         """Construct an initial dictionary for the superstructure."""
@@ -212,17 +221,6 @@ class Builder(object):
             for row in data.values()
         ], columns=df_index)
 
-        return df
-
-    @staticmethod
-    def finalize_superstructure(df: pd.DataFrame) -> pd.DataFrame:
-        """Ensure the dataframe is complete by matching the output activity
-        keys.
-        """
-        substitute = convert_key_to_fields(df.loc[:, FROM_ALL])
-        df[substitute.columns] = substitute
-        substitute = convert_key_to_fields(df.loc[:, TO_ALL])
-        df[substitute.columns] = substitute
         return df
 
     @staticmethod

--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -11,7 +11,7 @@ from .brightway import (
     swap_exchange_activities, nullify_exchanges,
     check_for_invalid_codes, handle_code_weirdness,
 )
-from .utils import SUPERSTRUCTURE, TO_ALL
+from .utils import SUPERSTRUCTURE, FROM_ALL, TO_ALL
 
 
 class Builder(object):
@@ -192,6 +192,8 @@ class Builder(object):
         """Ensure the dataframe is complete by matching the output activity
         keys.
         """
+        substitute = convert_key_to_fields(df.loc[:, FROM_ALL])
+        df[substitute.columns] = substitute
         substitute = convert_key_to_fields(df.loc[:, TO_ALL])
         df[substitute.columns] = substitute
         return df


### PR DESCRIPTION
Now possible to combine completely unrelated databases.

Additionally, if the given `superstructure` name is not an existing `bw.Database` a new one will be created.