### PR TITLE
Fix thoughtless pardiso exception

### DIFF
--- a/src/brightway.py
+++ b/src/brightway.py
@@ -158,7 +158,7 @@ def structure_exchanges(data: List[dict], super_db: str, deltas: set) -> List[Ex
     objects, adjusted for the superstructure database.
     """
     def alter_data(d):
-        d["amount"] = 0
+        d["amount"] = 0 if d["type"] != "production" else 1
         key = d["input"]
         d["input"] = (super_db, key[1]) if key[0] in deltas else key
         key = d["output"]

--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -43,14 +43,18 @@ class Builder(object):
         return builder
 
     @classmethod
-    def superstructure_from_databases(cls, databases: List[str], superstructure: str) -> 'Builder':
+    def superstructure_from_databases(cls, databases: List[str],
+                                      superstructure: Optional[str] = None) -> 'Builder':
         """Given a list of database names and the name of the superstructure,
         upgrade or create the superstructure database.
         """
         assert len(databases) >= 1, "At least one database should be included"
         assert len(databases) == len(set(databases)), "Duplicates are not allowed in the databases"
         assert all(db in bw.databases for db in databases), "All databases must exist in the project"
-        if superstructure not in bw.databases:
+        if superstructure is None:
+            # Default to first db in list if no name is given
+            superstructure, databases = databases[0], databases[1:]
+        elif superstructure not in bw.databases:
             db = bw.Database(superstructure)
             db.register()
         print("Superstructure: {}, deltas: {}".format(superstructure, ", ".join(databases)))

--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -130,6 +130,9 @@ class Builder(object):
         scen_idx = self.superstructure.columns.difference(SUPERSTRUCTURE, sort=False)
         delta_idx = scen_idx.drop([self.name])
 
+        # Drop the superstructure column
+        self.superstructure = self.superstructure.loc[:, SUPERSTRUCTURE.append(delta_idx)]
+
         # First, drop the rows where no delta file has any changes.
         only_nans = self.superstructure[delta_idx].isna().all(axis=1)
         self.superstructure = self.superstructure.drop(
@@ -137,7 +140,7 @@ class Builder(object):
         )
 
         # Now, drop the rows where there are no differences between the scenarios
-        same_vals = self.superstructure[scen_idx].nunique(axis=1) == 1
+        same_vals = self.superstructure[delta_idx].nunique(axis=1) == 1
         self.superstructure = self.superstructure.drop(
             self.superstructure.index[same_vals]
         )

--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -57,6 +57,8 @@ class Builder(object):
         elif superstructure not in bw.databases:
             db = bw.Database(superstructure)
             db.register()
+        elif superstructure in databases:
+            databases.remove(superstructure)
         print("Superstructure: {}, deltas: {}".format(superstructure, ", ".join(databases)))
         builder = cls.initialize(superstructure, databases)
         print("Amount of activities in superstructure: {}".format(len(builder.unique_codes)))


### PR DESCRIPTION
Processes with a zeroed production exchange cause matrix issues.

Additionally, increase the flexibility of building the superstructure and make sure the superstructure values themselves are not returned in the flow scenario dataframe.