### PR TITLE
Inlcude flow type field in exported superstructure

### DIFF
--- a/src/superstructure.py
+++ b/src/superstructure.py
@@ -237,6 +237,7 @@ class Builder(object):
             "from database": inp[0], "from key": inp,
             "to database": outp[0], "to key": outp,
             "from activity name": ss_exc.get("name"),
+            "flow type": ss_exc.get("type"),
         }
         if "type" in ss_exc and ss_exc["type"] == "biosphere":
             result["from categories"] = ss_exc.get("categories")

--- a/src/utils.py
+++ b/src/utils.py
@@ -42,6 +42,7 @@ SUPERSTRUCTURE = pd.Index([
     "to categories",
     "to database",
     "to key",
+    "flow type",
 ])
 
 


### PR DESCRIPTION
Make sure we're including the `flow type` field in the superstructure / flow scenario excel file we're creating.